### PR TITLE
feat: Prevent screen from sleeping during recording and playback

### DIFF
--- a/src/screens/Modern2025SpeechToTextScreen.tsx
+++ b/src/screens/Modern2025SpeechToTextScreen.tsx
@@ -19,6 +19,7 @@ import * as Haptics from 'expo-haptics';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'expo-blur';
 import { Ionicons } from '@expo/vector-icons';
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { ModernCard } from '../components/ModernCard';
 import { StorageService } from '../services/storage';
 import { OpenAIService } from '../services/openai';
@@ -43,6 +44,19 @@ export const Modern2025SpeechToTextScreen: React.FC = () => {
   const colors = isDark ? designTokens.colors.dark : designTokens.colors.light;
   const screenTheme = getScreenTheme('Speech to Text', isDark);
   const { t } = useTranslation();
+
+  // Keep screen awake while recording
+  useEffect(() => {
+    if (isRecording) {
+      activateKeepAwakeAsync();
+    } else {
+      deactivateKeepAwake();
+    }
+
+    return () => {
+      deactivateKeepAwake();
+    };
+  }, [isRecording]);
 
   // Use useRef for Animated values to work in release builds
   const fadeAnim = useRef(new Animated.Value(0)).current;

--- a/src/screens/Modern2025TextToSpeechScreen.tsx
+++ b/src/screens/Modern2025TextToSpeechScreen.tsx
@@ -21,6 +21,7 @@ import * as FileSystem from 'expo-file-system';
 import { LinearGradient } from 'expo-linear-gradient';
 import { BlurView } from 'expo-blur';
 import { Ionicons } from '@expo/vector-icons';
+import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
 import { ModernCard } from '../components/ModernCard';
 import { StorageService } from '../services/storage';
 import { OpenAIService } from '../services/openai';
@@ -48,6 +49,19 @@ export const Modern2025TextToSpeechScreen: React.FC = () => {
   const colors = isDark ? designTokens.colors.dark : designTokens.colors.light;
   const screenTheme = getScreenTheme('Text to Speech', isDark);
   const { t } = useTranslation();
+
+  // Keep screen awake while generating or playing audio
+  useEffect(() => {
+    if (isGenerating || isPlaying) {
+      activateKeepAwakeAsync();
+    } else {
+      deactivateKeepAwake();
+    }
+
+    return () => {
+      deactivateKeepAwake();
+    };
+  }, [isGenerating, isPlaying]);
 
   // Use useRef for Animated values to work in release builds
   const fadeAnim = useRef(new Animated.Value(0)).current;


### PR DESCRIPTION
## Summary
Add screen keep-awake functionality to improve user experience during long recording and playback sessions.

## Features
- 🎤 Screen stays awake during speech recording in Speech to Text
- 🔊 Screen stays awake during audio generation in Text to Speech  
- 🎵 Screen stays awake during audio playback in Text to Speech

## Implementation
Uses `expo-keep-awake` to activate/deactivate keep-awake mode based on app state:
- Activates when recording starts or audio generation/playback begins
- Deactivates when the action completes
- Properly cleans up on component unmount

## Test Plan
- [x] Test that screen stays awake during recording
- [x] Test that screen stays awake during TTS generation
- [x] Test that screen stays awake during audio playback
- [x] Verify cleanup when navigating away from screens

🤖 Generated with [Claude Code](https://claude.ai/code)