### PR TITLE
Fix npm registry rate limiting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: |
+          for i in 1 2 3 4 5; do
+            npm ci --legacy-peer-deps && break || {
+              echo "Attempt $i failed, retrying in 10 seconds..."
+              sleep 10
+            }
+          done
 
       - name: Run linter
         run: npm run lint
@@ -50,7 +56,13 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: |
+          for i in 1 2 3 4 5; do
+            npm ci --legacy-peer-deps && break || {
+              echo "Attempt $i failed, retrying in 10 seconds..."
+              sleep 10
+            }
+          done
 
       - name: Setup Expo
         uses: expo/expo-github-action@v8
@@ -117,7 +129,13 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --legacy-peer-deps
+        run: |
+          for i in 1 2 3 4 5; do
+            npm ci --legacy-peer-deps && break || {
+              echo "Attempt $i failed, retrying in 10 seconds..."
+              sleep 10
+            }
+          done
 
       - name: Setup EAS
         uses: expo/expo-github-action@v8


### PR DESCRIPTION
## Summary
- Add retry logic to npm install commands in CI workflow
- Prevents build failures due to npm registry 429 rate limiting errors

## Changes
- Modified `.github/workflows/ci.yml` to add 5 retry attempts with 10 second delays
- Applied to all npm install steps in the workflow

## Test plan
- [x] CI workflow should retry npm install on failure
- [x] Builds should complete successfully even with temporary 429 errors
- [x] All existing tests and checks should continue to pass

🤖 Generated with [Claude Code](https://claude.ai/code)